### PR TITLE
Gem Dependency Updater: cross link PRs

### DIFF
--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -102,31 +102,14 @@ class GemDependencyUpdater
       puts "Pull request already exists for branch '#{branch_name}'."
       return
     end
-
-    update_origin_pull_request
   end
 
   def pr_body
     <<~PR_BODY
-      This PR updates the #{@gem_name} to the latest feature branch.
+    [#{@github_event['pull_request']['repository']['name']} PR](#{@github_event['pull_request']['html_url']})
 
-      [#{@gem_name} PR](#{@github_event['pull_request']['html_url']})
+    This PR updates #{@github_event['pull_request']['repository']['name']} to the latest feature branch.
     PR_BODY
-  end
-
-  def update_origin_pull_request
-    pr_info_json = execute_command("gh pr view --json number,headRepository,url")
-    pr_info = JSON.parse(pr_info_json)
-
-    pr_link = "[#{pr_info['headRepository']['name']} ##{pr_info['number']}](#{pr_info['url']})"
-
-    current_body = @github_event['pull_request']['body']
-
-    return if current_body.include?(pr_link)
-
-    updated_pr_body = "#{current_body}\n\n#{pr_link}"
-
-    execute_command("gh pr edit #{@github_event['pull_request']['number']} --body \"#{updated_pr_body}\"")
   end
 
   def configure_git_user

--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -110,7 +110,7 @@ class GemDependencyUpdater
     <<~PR_BODY
       This PR updates the #{@gem_name} to the latest feature branch.
 
-      [#{@gem_name} PR](#{@github_event['pull_request']['url']})
+      [#{@gem_name} PR](#{@github_event['pull_request']['html_url']})
     PR_BODY
   end
 

--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -106,9 +106,9 @@ class GemDependencyUpdater
 
   def pr_body
     <<~PR_BODY
-    [#{@github_event['pull_request']['repository']['name']} PR](#{@github_event['pull_request']['html_url']})
+    [#{@github_event['repository']['name']} PR](#{@github_event['pull_request']['html_url']})
 
-    This PR updates #{@github_event['pull_request']['repository']['name']} to the latest feature branch.
+    This PR updates #{@github_event['repository']['name']} to the latest feature branch.
     PR_BODY
   end
 


### PR DESCRIPTION
Adds a link to the PR descriptions, that point to the gem PR. As as result Github will reference the PRs in the gem PR.

Example PR in sofatutor-main: (The "SPASS Changes" link will become obsolete. Will approach this next.)
![Bildschirmfoto 2025-02-19 um 16 07 11](https://github.com/user-attachments/assets/439d8207-a8d3-4570-a3e7-e14ba15bcdd0)

This is the according SPASS PR:
![Bildschirmfoto 2025-02-19 um 16 07 26](https://github.com/user-attachments/assets/84990a2a-61aa-4d84-be5c-f514d14e936f)
