### PR TITLE
Improve `git fetch/pull` performance (and add bundler cache)

### DIFF
--- a/.github/actions/gem-dependency-updater/action.yml
+++ b/.github/actions/gem-dependency-updater/action.yml
@@ -23,6 +23,8 @@ runs:
     - uses: sofatutor/setup-ruby@master
       with:
         ruby-version: '3.2'
+        bundler-cache: true
+        cache-version: 2
 
     - name: Run GemDependencyUpdater Ruby Script
       shell: bash

--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -54,7 +54,7 @@ class GemDependencyUpdater
         || git checkout -b #{dependent_repo_branch_name}
     CMD
     execute_command(checkout_cmd, "Failed to checkout or create branch '#{dependent_repo_branch_name}'.")
-    execute_command("git pull", "Failed to pull latest changes for branch '#{dependent_repo_branch_name}'.", graceful: true)
+    execute_command("git pull origin #{dependent_repo_branch_name}", "Failed to pull latest changes for branch '#{dependent_repo_branch_name}'.", graceful: true)
   end
 
   def update_gem_dependency

--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'benchmark'
 require 'json'
 
 class GemDependencyUpdater
@@ -119,7 +120,10 @@ class GemDependencyUpdater
 
   def execute_command(command, error_message = nil, graceful: false)
     puts "Executing: #{command}"
-    output = `#{command} 2>&1`
+    output = nil
+    time = Benchmark.measure do
+      output = `#{command} 2>&1`
+    end
 
     unless $?.success?
       error_message ||= "Command failed: #{command}"
@@ -131,6 +135,7 @@ class GemDependencyUpdater
       end
     end
 
+    puts "Execution time: #{time.real} seconds"
     output
   end
 end

--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -47,7 +47,7 @@ class GemDependencyUpdater
   end
 
   def checkout_branch
-    execute_command("git fetch --depth=1 origin", "Failed to fetch from origin.")
+    execute_command("git fetch --depth=1 origin #{dependent_repo_branch_name}", "Failed to fetch from origin.", graceful: true)
     checkout_cmd = <<~CMD
       git checkout #{dependent_repo_branch_name} 2>/dev/null \
         || git checkout -b #{dependent_repo_branch_name} origin/#{dependent_repo_branch_name} 2>/dev/null \


### PR DESCRIPTION
fixes #7 

This cut the execution time in half:
* jobs with `main` branch: https://github.com/sofatutor/SPASS/actions/runs/13544480275
* jobs with this branch: https://github.com/sofatutor/SPASS/actions/runs/13544790636