### PR TITLE
create PRs in draft state

### DIFF
--- a/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
+++ b/.github/actions/gem-dependency-updater/scripts/gem_dependency_updater.rb
@@ -92,7 +92,8 @@ class GemDependencyUpdater
       "--title \"#{sc_number} Update #{@gem_name}: #{pr_title.strip}\"",
       "--body \"#{pr_body}\"",
       "--head #{dependent_repo_branch_name}",
-      "--base #{BASE_BRANCH}"
+      "--base #{BASE_BRANCH}",
+      '--draft'
     ].join(' ')
 
     puts "Creating pull request for branch '#{branch_name}'..."


### PR DESCRIPTION
In the future draft PRs will run a reduced set of workflows to save time and money on the workers. So we create PRs in draft state. Once you feel like your PRs is ready, move it to ready for review manually.