### PR TITLE
Optimise Gem Dependency updater

### DIFF
--- a/.github/actions/gem-dependency-updater/action.yml
+++ b/.github/actions/gem-dependency-updater/action.yml
@@ -24,7 +24,7 @@ runs:
         repository: ${{ inputs.repo }}
         token: ${{ inputs.token }}
 
-    - uses: sofatutor/setup-ruby@master
+    - uses: sofatutor/setup-ruby@v1.238.0
       with:
         bundler-cache: false
 

--- a/.github/actions/gem-dependency-updater/action.yml
+++ b/.github/actions/gem-dependency-updater/action.yml
@@ -26,9 +26,7 @@ runs:
 
     - uses: sofatutor/setup-ruby@master
       with:
-        ruby-version: '3.2'
-        bundler-cache: true
-        cache-version: 2
+        bundler-cache: false
 
     - name: Run GemDependencyUpdater Ruby Script
       shell: bash


### PR DESCRIPTION
The setup-ruby action by default enables bundler caching, which triggers bundle install to install all gems from the Gemfile.lock