### PR TITLE
Flow setup-ruby master

### DIFF
--- a/.github/actions/gem-dependency-updater/action.yml
+++ b/.github/actions/gem-dependency-updater/action.yml
@@ -24,7 +24,7 @@ runs:
         repository: ${{ inputs.repo }}
         token: ${{ inputs.token }}
 
-    - uses: sofatutor/setup-ruby@v1.238.0
+    - uses: sofatutor/setup-ruby@master
       with:
         bundler-cache: false
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update `gem-dependency-updater` action to use `sofatutor/setup-ruby@master`.

The previously pinned version (`@v1.238.0`) did not include Ruby 3.3.9, which was causing CI failures.

---
[Slack Thread](https://sofatutor.slack.com/archives/C067Y712SU9/p1773063897669699?thread_ts=1773063897.669699&cid=C067Y712SU9)

<p><a href="https://cursor.com/agents/bc-a1991ad3-a460-5ae8-95dc-7257db5c95dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1991ad3-a460-5ae8-95dc-7257db5c95dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->